### PR TITLE
ci(publish): add write permission

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,9 @@ name: PR Release
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+
 jobs:
   pr-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Thank you for using PR Voyager 🚀

Add permission to resolve the following error:

https://github.com/steelydylan/browser-type-resolver/actions/runs/6008804690/job/16297044049

> Resource not accessible by integration